### PR TITLE
refactor(next-config): remove Prisma plugin dependency for cleaner configuration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,6 @@
       "name": "@repo/next-config",
       "version": "0.0.0",
       "dependencies": {
-        "@prisma/nextjs-monorepo-workaround-plugin": "^6.5.0",
         "@t3-oss/env-core": "^0.12.0",
         "@t3-oss/env-nextjs": "^0.12.0",
         "zod": "^3.24.2",
@@ -325,8 +324,6 @@
     "@petamoriken/float16": ["@petamoriken/float16@3.9.2", "", {}, "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="],
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.7", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ=="],
-
-    "@prisma/nextjs-monorepo-workaround-plugin": ["@prisma/nextjs-monorepo-workaround-plugin@6.5.0", "", {}, "sha512-W//PmOanuqx7+xUvj3529wpC+6ZQLwtv+JEcMR5PVubUmKyaduhOdDvVEvjACo9sN7nAqVBTFDHMBarIeOw6Ig=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.0", "", {}, "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="],
 

--- a/packages/next-config/index.ts
+++ b/packages/next-config/index.ts
@@ -1,6 +1,4 @@
 import path from 'node:path'
-// @ts-expect-error No declaration file
-import { PrismaPlugin } from '@prisma/nextjs-monorepo-workaround-plugin'
 import type { NextConfig } from 'next'
 
 export const config: NextConfig = {
@@ -11,13 +9,5 @@ export const config: NextConfig = {
   outputFileTracingRoot: path.join(__dirname, '../../'),
   images: {
     formats: ['image/avif', 'image/webp']
-  },
-  webpack(config, { isServer }) {
-    if (isServer) {
-      config.plugins = config.plugins || []
-      config.plugins.push(new PrismaPlugin())
-    }
-
-    return config
   }
 }

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -7,7 +7,6 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@prisma/nextjs-monorepo-workaround-plugin": "^6.5.0",
     "@t3-oss/env-core": "^0.12.0",
     "@t3-oss/env-nextjs": "^0.12.0",
     "zod": "^3.24.2"


### PR DESCRIPTION
This pull request includes changes to the `packages/next-config` directory to remove the `@prisma/nextjs-monorepo-workaround-plugin` dependency and its related configuration.

Removal of Prisma plugin:

* [`packages/next-config/index.ts`](diffhunk://#diff-d1488b0eb112c78b0545bc4aded75c054d58de1929839b31bc45a7c7fe8ce9beL2-L3): Removed the import of `PrismaPlugin` and the `webpack` configuration that added `PrismaPlugin` to the plugins array. [[1]](diffhunk://#diff-d1488b0eb112c78b0545bc4aded75c054d58de1929839b31bc45a7c7fe8ce9beL2-L3) [[2]](diffhunk://#diff-d1488b0eb112c78b0545bc4aded75c054d58de1929839b31bc45a7c7fe8ce9beL14-L21)
* [`packages/next-config/package.json`](diffhunk://#diff-ccf6e468140b442c43b374a530b3a1e789c56579e7411ddd954588f374624c85L10): Removed `@prisma/nextjs-monorepo-workaround-plugin` from the dependencies.