### PR TITLE
feat: add middleware for auth

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -10,6 +10,8 @@ export const config = {
     // Skip Next.js internals and all static files, unless found in search params
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
-    '/(api|trpc)(.*)'
+    '/(api|trpc)(.*)',
+    // Protected routes
+    '/dashboard/(.*)'
   ]
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,5 +1,19 @@
-import { authMiddleware } from '@repo/auth/middleware'
-import type { NextRequest } from 'next/server'
+import { getSessionCookie } from '@repo/auth/middleware'
+import { type NextRequest, NextResponse } from 'next/server'
+
+const isProtectedRoute = (request: NextRequest) => {
+  return request.url.includes('/dashboard')
+}
+
+const authMiddleware = (request: NextRequest) => {
+  const session = getSessionCookie(request)
+
+  if (isProtectedRoute(request) && !session) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  return NextResponse.next()
+}
 
 export function middleware(request: NextRequest) {
   return authMiddleware(request)

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,19 +1,5 @@
-import { getSessionCookie } from '@repo/auth/middleware'
-import { type NextRequest, NextResponse } from 'next/server'
-
-const isProtectedRoute = (request: NextRequest) => {
-  return request.url.includes('/dashboard')
-}
-
-const authMiddleware = (request: NextRequest) => {
-  const session = getSessionCookie(request)
-
-  if (isProtectedRoute(request) && !session) {
-    return NextResponse.redirect(new URL('/login', request.url))
-  }
-
-  return NextResponse.next()
-}
+import { authMiddleware } from '@repo/auth/middleware'
+import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
   return authMiddleware(request)

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,15 @@
+import { authMiddleware } from '@repo/auth/middleware'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  return authMiddleware(request)
+}
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and all static files, unless found in search params
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)'
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,6 @@
       "name": "@repo/next-config",
       "version": "0.0.0",
       "dependencies": {
-        "@prisma/nextjs-monorepo-workaround-plugin": "^6.5.0",
         "@t3-oss/env-core": "^0.12.0",
         "@t3-oss/env-nextjs": "^0.12.0",
         "zod": "^3.24.2",
@@ -325,8 +324,6 @@
     "@petamoriken/float16": ["@petamoriken/float16@3.9.2", "", {}, "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="],
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.7", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ=="],
-
-    "@prisma/nextjs-monorepo-workaround-plugin": ["@prisma/nextjs-monorepo-workaround-plugin@6.5.0", "", {}, "sha512-W//PmOanuqx7+xUvj3529wpC+6ZQLwtv+JEcMR5PVubUmKyaduhOdDvVEvjACo9sN7nAqVBTFDHMBarIeOw6Ig=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.0", "", {}, "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@repo/database": "*",
         "@t3-oss/env-nextjs": "^0.12.0",
         "better-auth": "1.2.4",
+        "better-fetch": "^1.1.2",
         "zod": "^3.24.2",
       },
       "devDependencies": {
@@ -519,6 +520,8 @@
     "better-auth": ["better-auth@1.2.4", "", { "dependencies": { "@better-auth/utils": "0.2.3", "@better-fetch/fetch": "^1.1.15", "@noble/ciphers": "^0.6.0", "@noble/hashes": "^1.6.1", "@simplewebauthn/browser": "^13.0.0", "@simplewebauthn/server": "^13.0.0", "better-call": "^1.0.3", "defu": "^6.1.4", "jose": "^5.9.6", "kysely": "^0.27.6", "nanostores": "^0.11.3", "valibot": "1.0.0-beta.15", "zod": "^3.24.1" } }, "sha512-/ZK2jbUjm8JwdeCLFrUWUBmexPyI9PkaLVXWLWtN60sMDHTY8B5G72wcHglo1QMFBaw4G0qFkP5ayl9k6XfDaA=="],
 
     "better-call": ["better-call@1.0.5", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-rAT73GWIJ8LbSP8Y3BdJnY1hwAiQPRRmUJ4R3YVhcVGS927l3eTXG5o5TD6Bv6je6ygjdx6iVq3/BU49eGUCHg=="],
+
+    "better-fetch": ["better-fetch@1.1.2", "", {}, "sha512-Qxvnc3WAbpNZcVXxqKmYHp7nCbAhG/gg+jOIHWep7eJxKZyogsymi+iHoHpbCSt7WCET78LCPiqs9MuSZ6+y7Q=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,6 @@
         "@repo/database": "*",
         "@t3-oss/env-nextjs": "^0.12.0",
         "better-auth": "1.2.4",
-        "better-fetch": "^1.1.2",
         "zod": "^3.24.2",
       },
       "devDependencies": {
@@ -520,8 +519,6 @@
     "better-auth": ["better-auth@1.2.4", "", { "dependencies": { "@better-auth/utils": "0.2.3", "@better-fetch/fetch": "^1.1.15", "@noble/ciphers": "^0.6.0", "@noble/hashes": "^1.6.1", "@simplewebauthn/browser": "^13.0.0", "@simplewebauthn/server": "^13.0.0", "better-call": "^1.0.3", "defu": "^6.1.4", "jose": "^5.9.6", "kysely": "^0.27.6", "nanostores": "^0.11.3", "valibot": "1.0.0-beta.15", "zod": "^3.24.1" } }, "sha512-/ZK2jbUjm8JwdeCLFrUWUBmexPyI9PkaLVXWLWtN60sMDHTY8B5G72wcHglo1QMFBaw4G0qFkP5ayl9k6XfDaA=="],
 
     "better-call": ["better-call@1.0.5", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-rAT73GWIJ8LbSP8Y3BdJnY1hwAiQPRRmUJ4R3YVhcVGS927l3eTXG5o5TD6Bv6je6ygjdx6iVq3/BU49eGUCHg=="],
-
-    "better-fetch": ["better-fetch@1.1.2", "", {}, "sha512-Qxvnc3WAbpNZcVXxqKmYHp7nCbAhG/gg+jOIHWep7eJxKZyogsymi+iHoHpbCSt7WCET78LCPiqs9MuSZ6+y7Q=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 

--- a/packages/auth/middleware.ts
+++ b/packages/auth/middleware.ts
@@ -1,0 +1,17 @@
+import { getSessionCookie } from 'better-auth/cookies'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+const isProtectedRoute = (request: NextRequest) => {
+  return request.url.includes('/dashboard')
+}
+
+export const authMiddleware = (request: NextRequest) => {
+  const session = getSessionCookie(request)
+
+  if (isProtectedRoute(request) && !session) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  return NextResponse.next()
+}

--- a/packages/auth/middleware.ts
+++ b/packages/auth/middleware.ts
@@ -1,17 +1,1 @@
-import { getSessionCookie } from 'better-auth/cookies'
-import type { NextRequest } from 'next/server'
-import { NextResponse } from 'next/server'
-
-const isProtectedRoute = (request: NextRequest) => {
-  return request.url.includes('/dashboard')
-}
-
-export const authMiddleware = (request: NextRequest) => {
-  const session = getSessionCookie(request)
-
-  if (isProtectedRoute(request) && !session) {
-    return NextResponse.redirect(new URL('/login', request.url))
-  }
-
-  return NextResponse.next()
-}
+export { getSessionCookie } from 'better-auth/cookies'

--- a/packages/auth/middleware.ts
+++ b/packages/auth/middleware.ts
@@ -1,1 +1,27 @@
-export { getSessionCookie } from 'better-auth/cookies'
+import { betterFetch } from '@better-fetch/fetch'
+import { type NextRequest, NextResponse } from 'next/server'
+import type { auth } from './server'
+
+type Session = typeof auth.$Infer.Session
+
+const isProtectedRoute = (request: NextRequest) => {
+  return request.url.includes('/dashboard')
+}
+
+export const authMiddleware = async (request: NextRequest) => {
+  const { data: session } = await betterFetch<Session>(
+    '/api/auth/get-session',
+    {
+      baseURL: request.nextUrl.origin,
+      headers: {
+        cookie: request.headers.get('cookie') || '' // Forward the cookies from the request
+      }
+    }
+  )
+
+  if (isProtectedRoute(request) && !session) {
+    return NextResponse.redirect(new URL('/sign-in', request.url))
+  }
+
+  return NextResponse.next()
+}

--- a/packages/auth/middleware.ts
+++ b/packages/auth/middleware.ts
@@ -1,26 +1,15 @@
-import { betterFetch } from '@better-fetch/fetch'
+import { getSessionCookie } from 'better-auth/cookies'
 import { type NextRequest, NextResponse } from 'next/server'
-import type { auth } from './server'
-
-type Session = typeof auth.$Infer.Session
 
 const isProtectedRoute = (request: NextRequest) => {
   return request.url.includes('/dashboard')
 }
 
-export const authMiddleware = async (request: NextRequest) => {
-  const { data: session } = await betterFetch<Session>(
-    '/api/auth/get-session',
-    {
-      baseURL: request.nextUrl.origin,
-      headers: {
-        cookie: request.headers.get('cookie') || '' // Forward the cookies from the request
-      }
-    }
-  )
+export const authMiddleware = (request: NextRequest) => {
+  const session = getSessionCookie(request)
 
   if (isProtectedRoute(request) && !session) {
-    return NextResponse.redirect(new URL('/sign-in', request.url))
+    return NextResponse.redirect(new URL('/login', request.url))
   }
 
   return NextResponse.next()

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,6 +17,7 @@
     "@repo/database": "*",
     "@t3-oss/env-nextjs": "^0.12.0",
     "better-auth": "1.2.4",
+    "better-fetch": "^1.1.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,7 +17,6 @@
     "@repo/database": "*",
     "@t3-oss/env-nextjs": "^0.12.0",
     "better-auth": "1.2.4",
-    "better-fetch": "^1.1.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,6 +5,7 @@
   "exports": {
     "./client": "./client.ts",
     "./server": "./server.ts",
+    "./middleware": "./middleware.ts",
     "./keys": "./keys.ts"
   },
   "scripts": {

--- a/packages/next-config/index.ts
+++ b/packages/next-config/index.ts
@@ -1,6 +1,4 @@
 import path from 'node:path'
-// @ts-expect-error No declaration file
-import { PrismaPlugin } from '@prisma/nextjs-monorepo-workaround-plugin'
 import type { NextConfig } from 'next'
 
 export const config: NextConfig = {
@@ -11,13 +9,5 @@ export const config: NextConfig = {
   outputFileTracingRoot: path.join(__dirname, '../../'),
   images: {
     formats: ['image/avif', 'image/webp']
-  },
-  webpack(config, { isServer }) {
-    if (isServer) {
-      config.plugins = config.plugins || []
-      config.plugins.push(new PrismaPlugin())
-    }
-
-    return config
   }
 }

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -7,7 +7,6 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@prisma/nextjs-monorepo-workaround-plugin": "^6.5.0",
     "@t3-oss/env-core": "^0.12.0",
     "@t3-oss/env-nextjs": "^0.12.0",
     "zod": "^3.24.2"


### PR DESCRIPTION
This pull request includes updates to the middleware handling, authentication, and configuration for the Next.js application. The changes introduce a new authentication middleware, update the package exports, and remove an unused Prisma plugin.

Middleware and authentication updates:

* [`apps/web/middleware.ts`](diffhunk://#diff-63df75659fc4d32b8f4a402f90ded1b436199e5a75c705619496af33c7aa02c7R1-R17): Added the `authMiddleware` function to handle authentication for specific routes and configured the `matcher` to specify which routes should use the middleware.
* [`packages/auth/middleware.ts`](diffhunk://#diff-8eed085be01d95bf0540018b16f5a0163271a77f67ff43c279793f6e87c3e4d5R1-R16): Implemented the `authMiddleware` function to check for session cookies and redirect unauthenticated users from protected routes to the login page.
* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fR8): Added the `middleware.ts` file to the package exports.

Configuration changes:

* [`packages/next-config/index.ts`](diffhunk://#diff-d1488b0eb112c78b0545bc4aded75c054d58de1929839b31bc45a7c7fe8ce9beL2-L3): Removed the `PrismaPlugin` from the Next.js configuration as it is no longer needed. [[1]](diffhunk://#diff-d1488b0eb112c78b0545bc4aded75c054d58de1929839b31bc45a7c7fe8ce9beL2-L3) [[2]](diffhunk://#diff-d1488b0eb112c78b0545bc4aded75c054d58de1929839b31bc45a7c7fe8ce9beL14-L21)
* [`packages/next-config/package.json`](diffhunk://#diff-ccf6e468140b442c43b374a530b3a1e789c56579e7411ddd954588f374624c85L10): Removed the `@prisma/nextjs-monorepo-workaround-plugin` dependency.